### PR TITLE
Picklability

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -116,6 +116,17 @@ class Castra(object):
         else:
             self.save_partition_list()
 
+    def __getstate__(self):
+        self.save_partition_list()
+        return (self.path, self._explicitly_given_path)
+
+    def __setstate__(self, state):
+        self.path = state[0]
+        self._explicitly_given_path = state[1]
+        self.meta_path = self.dirname('meta')
+        self.load_meta()
+        self.load_partition_list()
+
 
 def select_partitions(partition_list, key):
     """ Select partitions from partition list given slice

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pandas.util.testing as tm
 from castra import Castra
 import tempfile
+import pickle
 
 
 A = pd.DataFrame({'x': [1, 2],
@@ -59,3 +60,15 @@ def test_load_Castra():
 
     loaded = Castra(path=path)
     tm.assert_frame_equal(pd.concat([A, B]), loaded[:])
+
+
+def test_pickle_Castra():
+    path = tempfile.mkdtemp(prefix='castra-')
+    c = Castra(path=path, template=A)
+    c.extend(A)
+    c.extend(B)
+
+    dumped = pickle.dumps(c)
+    undumped = pickle.loads(dumped)
+
+    tm.assert_frame_equal(pd.concat([A, B]), undumped[:])

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -43,6 +43,11 @@ def test_context_manager():
         assert os.path.exists(c.path)
     assert not os.path.exists(c.path)
 
+    path = tempfile.mkdtemp(prefix='castra-')
+    with Castra(path=path, template=A) as c:
+        assert os.path.exists(c.path)
+    assert os.path.exists(c.path)
+
 
 def test_load_Castra():
     path = tempfile.mkdtemp(prefix='castra-')


### PR DESCRIPTION
`__getstate__` and `__setstate__` probably only need to maintain the path and not the rest of the metadata.