### PR TITLE
Support object dtype with msgpack serialization

### DIFF
--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -119,3 +119,12 @@ def test_pickle_Castra():
     undumped = pickle.loads(dumped)
 
     tm.assert_frame_equal(pd.concat([A, B]), undumped[:])
+
+
+def test_text():
+    df = pd.DataFrame({'name': ['Alice', 'Bob'],
+                       'balance': [100, 200]}, columns=['name', 'balance'])
+    with Castra(template=df) as c:
+        c.extend(df)
+
+        tm.assert_frame_equal(c[:], df)


### PR DESCRIPTION
Msgpack serializes series with object dtype quite well.

See http://mrocklin.github.com/blog/work/2015/03/16/Fast-Serialization

This branches file packing on dtype, using msgpack+blosc for object dtype
and using bloscpack for everything else

Example
-------

```python
df = pd.DataFrame({'name': ['Alice', 'Bob'],
                   'balance': [100, 200]}, columns=['name', 'balance'])

with Castra(template=df) as c:
    c.extend(df)

    tm.assert_frame_equal(c[:], df)
```