### PR TITLE
Column access

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -104,6 +104,9 @@ class Castra(object):
         return os.path.join(self.path, *args)
 
     def load_partition(self, name, columns):
+        if not isinstance(columns, list):
+            df = self.load_partition(name, [columns])
+            return df[df.columns[0]]
         arrays = [unpack_file(self.dirname(name, col))
                    for col in columns]
         index = unpack_file(self.dirname(name, '.index'))

--- a/castra/core.py
+++ b/castra/core.py
@@ -103,21 +103,24 @@ class Castra(object):
     def dirname(self, *args):
         return os.path.join(self.path, *args)
 
-    def load_partition(self, name):
-        columns = [unpack_file(self.dirname(name, col))
-                   for col in self.columns]
+    def load_partition(self, name, columns):
+        arrays = [unpack_file(self.dirname(name, col))
+                   for col in columns]
         index = unpack_file(self.dirname(name, '.index'))
 
-        return pd.DataFrame(dict(zip(self.columns, columns)),
-                            columns=self.columns,
+        return pd.DataFrame(dict(zip(columns, arrays)),
+                            columns=columns,
                             index=pd.Index(index, dtype=self.index_dtype))
 
     def __getitem__(self, key):
-        assert isinstance(key, slice)
+        if isinstance(key, tuple):
+            key, columns = key
+        else:
+            columns = self.columns
         start, stop = key.start, key.stop
         names = select_partitions(self.partitions, key)
 
-        data_frames = [self.load_partition(name) for name in names]
+        data_frames = [self.load_partition(name, columns) for name in names]
 
         data_frames[0] = data_frames[0].loc[start:]
         data_frames[-1] = data_frames[-1].loc[:stop]

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -143,6 +143,15 @@ def test_text():
         tm.assert_frame_equal(c[:], df)
 
 
+def test_column_access():
+    with Castra(template=A) as c:
+        c.extend(A)
+        c.extend(B)
+        df = c[:, ['x']]
+
+        tm.assert_frame_equal(df, pd.concat([A[['x']], B[['x']]]))
+
+
 def test_index_dtype_matches_template():
     with Castra(template=A) as c:
         assert c.partitions.index.dtype == A.index.dtype

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -151,6 +151,9 @@ def test_column_access():
 
         tm.assert_frame_equal(df, pd.concat([A[['x']], B[['x']]]))
 
+        df = c[:, 'x']
+        tm.assert_series_equal(df, pd.concat([A.x, B.x]))
+
 
 def test_index_dtype_matches_template():
     with Castra(template=A) as c:


### PR DESCRIPTION
Fixes #1 

```python
In [1]: import pandas as pd

In [2]: A = pd.DataFrame({'x': [1, 2],
   ...:                   'y': [1., 2.]},
   ...:                  columns=['x', 'y'],
   ...:                  index=[1, 2])

In [3]: 

In [3]: B = pd.DataFrame({'x': [10, 20],
   ...:                   'y': [10., 20.]},
   ...:                  columns=['x', 'y'],
   ...:                  index=[10, 20])

In [4]: from castra import Castra

In [5]: c = Castra(template=A)

In [6]: c.extend(A)

In [7]: c.extend(B)

In [8]: c[:]
Out[8]: 
     x   y
1    1   1
2    2   2
10  10  10
20  20  20

In [9]: c[:, ['y', 'x']]
Out[9]: 
     y   x
1    1   1
2    2   2
10  10  10
20  20  20

In [10]: c[:, ['y']]
Out[10]: 
     y
1    1
2    2
10  10
20  20

In [11]: c[:, 'y']
Out[11]: 
1      1
2      2
10    10
20    20
Name: y, dtype: float64
```