### PR TITLE
To dask

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -104,6 +104,9 @@ class Castra(object):
         return os.path.join(self.path, *args)
 
     def load_partition(self, name, columns):
+        if not isinstance(columns, list):
+            df = self.load_partition(name, [columns])
+            return df[df.columns[0]]
         arrays = [unpack_file(self.dirname(name, col))
                    for col in columns]
         index = unpack_file(self.dirname(name, '.index'))

--- a/castra/core.py
+++ b/castra/core.py
@@ -103,21 +103,24 @@ class Castra(object):
     def dirname(self, *args):
         return os.path.join(self.path, *args)
 
-    def load_partition(self, name):
-        columns = [unpack_file(self.dirname(name, col))
-                   for col in self.columns]
+    def load_partition(self, name, columns):
+        arrays = [unpack_file(self.dirname(name, col))
+                   for col in columns]
         index = unpack_file(self.dirname(name, '.index'))
 
-        return pd.DataFrame(dict(zip(self.columns, columns)),
-                            columns=self.columns,
+        return pd.DataFrame(dict(zip(columns, arrays)),
+                            columns=columns,
                             index=pd.Index(index, dtype=self.index_dtype))
 
     def __getitem__(self, key):
-        assert isinstance(key, slice)
+        if isinstance(key, tuple):
+            key, columns = key
+        else:
+            columns = self.columns
         start, stop = key.start, key.stop
         names = select_partitions(self.partitions, key)
 
-        data_frames = [self.load_partition(name) for name in names]
+        data_frames = [self.load_partition(name, columns) for name in names]
 
         data_frames[0] = data_frames[0].loc[start:]
         data_frames[-1] = data_frames[-1].loc[:stop]

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -143,6 +143,15 @@ def test_text():
         tm.assert_frame_equal(c[:], df)
 
 
+def test_column_access():
+    with Castra(template=A) as c:
+        c.extend(A)
+        c.extend(B)
+        df = c[:, ['x']]
+
+        tm.assert_frame_equal(df, pd.concat([A[['x']], B[['x']]]))
+
+
 def test_index_dtype_matches_template():
     with Castra(template=A) as c:
         assert c.partitions.index.dtype == A.index.dtype

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -158,3 +158,24 @@ def test_column_access():
 def test_index_dtype_matches_template():
     with Castra(template=A) as c:
         assert c.partitions.index.dtype == A.index.dtype
+
+
+def test_to_dask_dataframe():
+    try:
+        import dask.dataframe as dd
+    except ImportError:
+        return
+
+    with Castra(template=A) as c:
+        c.extend(A)
+        c.extend(B)
+
+        df = c.to_dask()
+        assert isinstance(df, dd.DataFrame)
+        assert list(df.divisions) == [2]
+        tm.assert_frame_equal(df.compute(), c[:])
+
+        df = c.to_dask('x')
+        assert isinstance(df, dd.Series)
+        assert list(df.divisions) == [2]
+        tm.assert_series_equal(df.compute(), c[:, 'x'])

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -151,6 +151,9 @@ def test_column_access():
 
         tm.assert_frame_equal(df, pd.concat([A[['x']], B[['x']]]))
 
+        df = c[:, 'x']
+        tm.assert_series_equal(df, pd.concat([A.x, B.x]))
+
 
 def test_index_dtype_matches_template():
     with Castra(template=A) as c:


### PR DESCRIPTION
This adds to #6 and adds a `to_dask` method to convert a Castra into a dask.dataframe.