### PR TITLE
Add minimum index value to castra

### DIFF
--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -166,6 +166,7 @@ def test_reload():
 
         assert c.columns == d.columns
         assert (c.partitions == d.partitions).all()
+        assert c.minimum == d.minimum
     finally:
         shutil.rmtree(path)
 
@@ -187,12 +188,12 @@ def test_to_dask_dataframe():
 
         df = c.to_dask()
         assert isinstance(df, dd.DataFrame)
-        assert list(df.divisions) == [2]
+        assert list(df.divisions) == [1, 2, 20]
         tm.assert_frame_equal(df.compute(), c[:])
 
         df = c.to_dask('x')
         assert isinstance(df, dd.Series)
-        assert list(df.divisions) == [2]
+        assert list(df.divisions) == [1, 2, 20]
         tm.assert_series_equal(df.compute(), c[:, 'x'])
 
 


### PR DESCRIPTION
Currently we record the maximum value of each incoming partition.
Assuming that partitions come in sequentially this gives us nice
min/max ranges on all partitions except the first, which is unbounded.

This adds a `.minimum` field to Castra to fill this place.

This feels a bit kludgy but does solve an immediate problem.
Alternative solutions welcome.

Knowing the minimum ends up being very useful when two tables interact.