### PR TITLE
Support naive indexes with castra

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -151,6 +151,15 @@ class Castra(object):
         # TODO: Ensure that df is consistent with existing data
         if not df.index.is_monotonic_increasing:
             df = df.sort_index(inplace=False)
+        if len(self.partitions) and df.index[0] < self.partitions.index[0]:
+            if is_trivial_index(df.index):
+                df = df.copy()
+                new_index = pd.Index(range(self.partitions.index[0] + 1,
+                                           self.partitions.index[0] + 1 + len(df)),
+                                    name = df.index.name)
+                df.index = new_index
+            else:
+                raise ValueError("Index of new dataframe less than known data")
         index = df.index.values
         partition_name = '--'.join([escape(index.min()), escape(index.max())])
 
@@ -389,3 +398,17 @@ def _categorize(categories, df):
                     for col in df.columns),
                 columns=df.columns,
                 index=df.index)
+
+
+def is_trivial_index(ind):
+    """ Is this index just 0..n ?
+
+    If so then we can probably ignore or change it around as necessary
+
+    >>> is_trivial_index(pd.Index([0, 1, 2]))
+    True
+
+    >>> is_trivial_index(pd.Index([0, 3, 5]))
+    False
+    """
+    return ind[0] == 0 and (ind == range(len(ind))).all()

--- a/castra/tests/test_core.py
+++ b/castra/tests/test_core.py
@@ -305,3 +305,25 @@ def test_minimum_dtype():
     with Castra(template=df) as c:
         c.extend(df)
         assert type(c.minimum) == type(c.partitions.index[0])
+
+
+def test_many_default_indexes():
+    a = pd.DataFrame({'x': [1, 2, 3]})
+    b = pd.DataFrame({'x': [4, 5, 6]})
+
+    with Castra(template=a) as c:
+        c.extend(a)
+        c.extend(b)
+
+        assert (c[:, 'x'].values == [1, 2, 3, 4, 5, 6]).all()
+
+
+def test_raise_error_on_mismatched_index():
+    a = pd.DataFrame({'x': [1, 2, 3]}, index=[1, 2, 3])
+    b = pd.DataFrame({'x': [4, 5, 6]}, index=[2, 3, 4])
+
+    with Castra(template=a) as c:
+        c.extend(a)
+
+        with pytest.raises(ValueError):
+            c.extend(b)


### PR DESCRIPTION
In cases where the user dumps many dataframes without a meaningful
index (like 0, 1, 2, ...) we assume that they don't mind us changing
these values to stack on on top of the other.

Example
-------

```python
In [1]: import pandas as pd

In [2]: a = pd.DataFrame({'x': [1, 2, 3]})

In [3]: b = pd.DataFrame({'x': [4, 5, 6]})

In [4]: from castra import Castra

In [5]: c = Castra(template=a)

In [6]: c.extend(a)

In [7]: c.extend(b)

In [8]: c[:]
Out[8]:
   x
0  1
1  2
2  3
3  4
4  5
5  6
```