### PR TITLE
Speedup loading of object columns

### DIFF
--- a/castra/core.py
+++ b/castra/core.py
@@ -308,8 +308,9 @@ def unpack_file(fn, encoding='utf8'):
         return bloscpack.unpack_ndarray_file(fn)
     except ValueError:
         with open(fn, 'rb') as f:
-            return np.array(msgpack.unpackb(blosc.decompress(f.read()),
-                                            encoding=encoding))
+            data = msgpack.unpackb(blosc.decompress(f.read()),
+                                   encoding=encoding)
+            return np.array(data, object, copy=False)
 
 
 def coerce_index(dt, o):


### PR DESCRIPTION
`np.array(data)` is much slower, and uses more memory than `np.array(data, object)` for object dtypes. This makes loading columns of text data ~12 times faster on my computer, and significantly reduces RAM usage when used from dask.